### PR TITLE
adjust to new archived API format

### DIFF
--- a/todo-list-macos/Services/SectionStore.swift
+++ b/todo-list-macos/Services/SectionStore.swift
@@ -11,21 +11,21 @@ struct SectionEntity: NetworkResponse, Identifiable {
     let id: Int
     let projectId: Int
     let name: String
-    let isArchived: Bool
+    let archivedAt: String?
     let createdAt: String
     
     func copyWith(
         id: Int? = nil,
         projectId: Int? = nil,
         name: String? = nil,
-        isArchived: Bool? = nil,
+        archivedAt: String? = nil,
         createdAt: String? = nil
     ) -> SectionEntity {
         SectionEntity(
             id: id ?? self.id,
             projectId: projectId ?? self.projectId,
             name: name ?? self.name,
-            isArchived: isArchived ?? self.isArchived,
+            archivedAt: archivedAt ?? self.archivedAt,
             createdAt: createdAt ?? self.createdAt
         )
     }
@@ -77,14 +77,5 @@ class SectionStore: ObservableObject {
     
     func onProjectDelete(projectId: Int) {
         self.sections.removeAll { $0.projectId == projectId }
-    }
-    
-    func onProjectArchive(projectId: Int) {
-        self.sections = self.sections.map { section in
-            guard section.projectId == projectId && !section.isArchived else {
-                return section
-            }
-            return section.copyWith(isArchived: true)
-        }
     }
 }

--- a/todo-list-macos/Services/TaskStore.swift
+++ b/todo-list-macos/Services/TaskStore.swift
@@ -14,7 +14,6 @@ struct TaskEntity: NetworkResponse, Identifiable {
     let name: String
     let description: String
     let isCompleted: Bool
-    let isArchived: Bool
     let createdAt: String
     
     func copyWith(
@@ -24,7 +23,6 @@ struct TaskEntity: NetworkResponse, Identifiable {
         name: String? = nil,
         description: String? = nil,
         isCompleted: Bool? = nil,
-        isArchived: Bool? = nil,
         createdAt: String? = nil
     ) -> TaskEntity {
         TaskEntity(
@@ -34,7 +32,6 @@ struct TaskEntity: NetworkResponse, Identifiable {
             name: name ?? self.name,
             description: description ?? self.description,
             isCompleted: isCompleted ?? self.isCompleted,
-            isArchived: isArchived ?? self.isArchived,
             createdAt: createdAt ?? self.createdAt
         )
     }
@@ -87,14 +84,5 @@ class TaskStore: ObservableObject {
     
     func onProjectDelete(projectId: Int) {
         self.tasks.removeAll { $0.projectId == projectId }
-    }
-    
-    func onProjectArchive(projectId: Int) {
-        self.tasks = self.tasks.map { task in
-            guard task.projectId == projectId && !task.isArchived else {
-                return task
-            }
-            return task.copyWith(isArchived: true)
-        }
     }
 }

--- a/todo-list-macos/Views/AppView.swift
+++ b/todo-list-macos/Views/AppView.swift
@@ -18,7 +18,7 @@ struct AppView: View {
     private var currentTitle: String {
         if let selectedProject,
            let project = projectStore.projectsById[selectedProject] {
-            return project.isArchived ? "\(project.name) (archived)" : project.name
+            return project.archivedAt != nil ? "\(project.name) (archived)" : project.name
         } else {
             return ""
         }

--- a/todo-list-macos/Views/ProjectActionsView.swift
+++ b/todo-list-macos/Views/ProjectActionsView.swift
@@ -32,7 +32,7 @@ struct ProjectActionsView: View {
                     Image(systemName: "trash")
                 }
                 .buttonStyle(CustomIconButtonStyle())
-                if project.isArchived {
+                if project.archivedAt != nil {
                     Button {
                         // TODO: add unarchiving
                         
@@ -102,10 +102,7 @@ struct ProjectActionsView: View {
                         Task {
                             do {
                                 archivingError = nil
-                                try await projectStore.archiveProject(projectId: projectId) {
-                                    sectionStore.onProjectArchive(projectId: projectId)
-                                    taskStore.onProjectArchive(projectId: projectId)
-                                }
+                                try await projectStore.archiveProject(projectId: projectId)
                                 archivingProject = false
                             } catch {
                                 archivingError = error

--- a/todo-list-macos/Views/ProjectView.swift
+++ b/todo-list-macos/Views/ProjectView.swift
@@ -38,7 +38,7 @@ struct ProjectView: View {
                                 Divider()
                             }
                             
-                            if !project.isArchived {
+                            if project.archivedAt == nil {
                                 InlineTaskEditor(projectId: projectId)
                                     .padding(.bottom, 8)
                                 

--- a/todo-list-macos/Views/SectionView.swift
+++ b/todo-list-macos/Views/SectionView.swift
@@ -37,14 +37,14 @@ struct SectionView: View {
                     Divider()
                 }
                 
-                if !section.isArchived {
+                if section.archivedAt == nil {
                     InlineTaskEditor(projectId: section.projectId, sectionId: section.id)
                         .padding(.bottom, 8)
                 }
                 
             }
             
-            if !section.isArchived {
+            if section.archivedAt == nil {
                 InlineSectionEditor(projectId: section.projectId)
             }
         }


### PR DESCRIPTION
## Description

Adjust to the DB changes made in https://github.com/Bloomca/todo-list-backend/pull/31. Now it is `archived_at` which is a timestamp.

Also archiving a parent does not archive children anymore; this is done so that unarchiving would preserve previous archived status.